### PR TITLE
Fixes compile error for wifi

### DIFF
--- a/BadgeCode/BadgeCode.ino
+++ b/BadgeCode/BadgeCode.ino
@@ -411,7 +411,7 @@ void wifiOn(){
   oled.putString ("Wifi ON");
   oled.setTextXY (2,2);
   oled.putString (ssid);
-  WiFi.softAP(ssid, NULL, 1, 0, 1);
+  WiFi.softAP(ssid, NULL, 1, 0);
   wifiStatus = 1;
   delay (2000);
   settingsMenu();


### PR DESCRIPTION
Fixes compile error I get in platformIO
```
/Projects/Badge-DC25/BadgeCode/BadgeCode/BadgeCode.ino: In function 'void wifiOn()':
/Projects/Badge-DC25/BadgeCode/BadgeCode/BadgeCode.ino:414:34: error: no matching function for call

 to 'WiFiClass::softAP(char [12], NULL, int, int, int)'
WiFi.softAP(ssid, NULL, 1, 0, 1);
^
In file included from /.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src/WiFi.h:
33:0,
from /Projects/Badge-DC25/BadgeCode/BadgeCode/BadgeCode.ino:20:
/.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src/WiFiAP.h:40:10: note: candida
te: bool WiFiAPClass::softAP(const char*, const char*, int, int)
bool softAP(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0);
^
/.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src/WiFiAP.h:40:10: note:   candi
date expects 4 arguments, 5 provided
*** [.pioenvs/esp32thing/src/BadgeCode.ino.o] Error 1
```